### PR TITLE
Update version.rb

### DIFF
--- a/lib/swagger-ui_rails/version.rb
+++ b/lib/swagger-ui_rails/version.rb
@@ -1,5 +1,5 @@
 module Swagger
   module UiRails
-    VERSION = "2.1.0-alpha.7.1"
+    VERSION = "2.1.0.alpha.7.1"
   end
 end


### PR DESCRIPTION
We ran into problems with 'bundle install' in some of our environments:

There was a ArgumentError while loading swagger-ui_rails.gemspec: 
Malformed version number string 2.1.0-alpha.7.1 from
/var/lib/jenkins/workspace/hawking-develop/vendor/bundle/ruby/1.9.1/bundler/gems/swagger-ui_rails-12a2704c2767/swagger-ui_rails.gemspec:8:in
`block in <main>'

results from Googling implicate the - in the version string.